### PR TITLE
fix: pull request filtered by label

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -378,8 +378,3 @@ async function getRemoteOriginURL() {
 
   return new TextDecoder().decode(await p.output());
 }
-
-
-function byLabelFilter(byLabelFilter: any) {
-
-}

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -164,10 +164,8 @@ export async function findPullRequests(options: FindPullRequestOptions) {
 
   const items = await resp.json()
   
-  return items.filter(pr => {
-    const labelNames = pr.labels.map(label => label.name)
-    return labelNames.includes(label)
-  });
+  return items
+  .filter(pr => pr.labels.map(label => label.name).includes(label));
 }
 
 export async function getPullRequest(options: GetPullRequestOptions) {

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -156,16 +156,18 @@ export async function findPullRequests(options: FindPullRequestOptions) {
   const resp = await octono.request("GET /repos/{owner}/{repo}/pulls", {
     owner: owner,
     repo: repo,
-    labels: label,
     state: state,
     headers: {
       authorization: `bearer ${await fetchGitHubToken()}`,
     },
   });
 
-  const items = await resp.json();
-
-  return items;
+  const items = await resp.json()
+  
+  return items.filter(pr => {
+    const labelNames = pr.labels.map(label => label.name)
+    return labelNames.includes(label)
+  });
 }
 
 export async function getPullRequest(options: GetPullRequestOptions) {
@@ -375,4 +377,9 @@ async function getRemoteOriginURL() {
   }
 
   return new TextDecoder().decode(await p.output());
+}
+
+
+function byLabelFilter(byLabelFilter: any) {
+
 }


### PR DESCRIPTION
This commit fixes the pull requests client request that does not filter by label, so we do it manually for the time being filtering the collection we get in the response, I also removed the label as parameter for the http request to octokit/octono