### PR TITLE
fix: improvint error logging and removing rebase out of merge pull request

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -162,7 +162,6 @@ export async function mergePullRequest(options: MergePullRequestOptions) {
       pull_number: number,
       commit_title: commit.title,
       commit_message: commit.message,
-      merge_method: "rebase",
       headers: {
         authorization: `bearer ${await fetchGitHubToken()}`,
       },

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -147,7 +147,7 @@ export async function closePullRequest(options: ClosePullRequestOptions) {
   );
 
   if (!resp.ok) {
-    throw new Error(JSON.stringify(resp.json()));
+    throw new Error(JSON.stringify(await resp.json()));
   }
 }
 
@@ -170,7 +170,7 @@ export async function mergePullRequest(options: MergePullRequestOptions) {
   );
 
   if (!resp.ok) {
-    throw new Error(JSON.stringify(resp.json()));
+    throw new Error(JSON.stringify(await resp.json()));
   }
 
   console.log(await resp.json());
@@ -257,7 +257,7 @@ export async function getBranch(options: GetBranchOptions) {
   );
 
   if (!resp.ok) {
-    throw new Error(JSON.stringify(resp.json()));
+    throw new Error(JSON.stringify(await resp.json()));
   }
 
   return await resp.json();
@@ -345,7 +345,7 @@ export async function getDraftReleaseByTag(options: GetReleaseByTagOptions) {
   );
 
   if (!resp.ok) {
-    throw new Error(JSON.stringify(resp.json()));
+    throw new Error(JSON.stringify(await resp.json()));
   }
 
   const releases = await resp.json();
@@ -375,7 +375,7 @@ export async function updateRelease(options: UpdateReleaseOptions) {
   );
 
   if (!resp.ok) {
-    throw new Error(JSON.stringify(resp.json()));
+    throw new Error(JSON.stringify(await resp.json()));
   }
 
   return await resp.json();


### PR DESCRIPTION
- Error logging came empty, awaiting now for a response from the async method
- Merge pull request is now in mode non-rebase