### PR TITLE
feat: merge method can be passed into mod.ts and close ts uses rebase

### DIFF
--- a/cli/cmd/close.ts
+++ b/cli/cmd/close.ts
@@ -46,6 +46,7 @@ export async function closeCommand(args: CloseCommandArgs) {
     owner,
     repo,
     number: pr.number,
+    mergeMethod: "rebase",
     commit: { title: `release: ${tag}` },
   });
 
@@ -76,6 +77,7 @@ export async function closeCommand(args: CloseCommandArgs) {
     {
       commit: { title: `chore: sync ${mainBranchName} -> ${developBranch}` },
       number: syncPr.number,
+      mergeMethod: "rebase",
       repo: repo,
       owner: owner,
     },

--- a/cli/cmd/close.ts
+++ b/cli/cmd/close.ts
@@ -3,6 +3,7 @@ import {
   getDraftReleaseByTag,
   getPullRequest,
   mergePullRequest,
+  MergeMethod,
   openPullRequest,
   updateRelease,
 } from "../deps.ts";
@@ -46,7 +47,7 @@ export async function closeCommand(args: CloseCommandArgs) {
     owner,
     repo,
     number: pr.number,
-    mergeMethod: "rebase",
+    mergeMethod: MergeMethod.Rebase,
     commit: { title: `release: ${tag}` },
   });
 
@@ -77,7 +78,7 @@ export async function closeCommand(args: CloseCommandArgs) {
     {
       commit: { title: `chore: sync ${mainBranchName} -> ${developBranch}` },
       number: syncPr.number,
-      mergeMethod: "rebase",
+      mergeMethod: MergeMethod.Rebase,
       repo: repo,
       owner: owner,
     },

--- a/cli/cmd/close.ts
+++ b/cli/cmd/close.ts
@@ -2,8 +2,8 @@ import {
   findPullRequests,
   getDraftReleaseByTag,
   getPullRequest,
-  mergePullRequest,
   MergeMethod,
+  mergePullRequest,
   openPullRequest,
   updateRelease,
 } from "../deps.ts";

--- a/cli/deps.ts
+++ b/cli/deps.ts
@@ -8,12 +8,12 @@ export {
   getOwnerAndRepo,
   getPullRequest,
   getReleaseByTag,
-  mergePullRequest,
+  mergeBranch,
   MergeMethod,
+  mergePullRequest,
   openPullRequest,
   renameBranch,
   updateRelease,
-  mergeBranch
 } from "../lib/mod.ts";
 
 // x/yargs

--- a/cli/deps.ts
+++ b/cli/deps.ts
@@ -9,6 +9,7 @@ export {
   getPullRequest,
   getReleaseByTag,
   mergePullRequest,
+  MergeMethod,
   openPullRequest,
   renameBranch,
   updateRelease,

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -22,6 +22,7 @@ export interface MergePullRequestOptions {
   owner: string;
   repo: string;
   number: number;
+  mergeMethod: string;
   commit: {
     title: string;
     message?: string;
@@ -103,7 +104,7 @@ export async function openPullRequest(options: OpenPullRequestOptions) {
   });
 
   if (!resp.ok) {
-    throw new Error(JSON.stringify(resp.json()));
+    throw new Error(JSON.stringify(await resp.json()));
   }
 
   const pr = await resp.json();
@@ -152,7 +153,7 @@ export async function closePullRequest(options: ClosePullRequestOptions) {
 }
 
 export async function mergePullRequest(options: MergePullRequestOptions) {
-  const { owner, repo, number, commit } = options;
+  const { owner, repo, number, commit, mergeMethod } = options;
 
   const resp = await octono.request(
     "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge",
@@ -162,6 +163,7 @@ export async function mergePullRequest(options: MergePullRequestOptions) {
       pull_number: number,
       commit_title: commit.title,
       commit_message: commit.message,
+      merge_method: mergeMethod,
       headers: {
         authorization: `bearer ${await fetchGitHubToken()}`,
       },

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -22,11 +22,17 @@ export interface MergePullRequestOptions {
   owner: string;
   repo: string;
   number: number;
-  mergeMethod: string;
+  mergeMethod: MergeMethod;
   commit: {
     title: string;
     message?: string;
   };
+}
+
+export enum MergeMethod{
+  Rebase = "rebase",
+  Squash = "squash",
+  Merge = "merge"
 }
 
 export interface FindPullRequestOptions {

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -29,10 +29,10 @@ export interface MergePullRequestOptions {
   };
 }
 
-export enum MergeMethod{
+export enum MergeMethod {
   Rebase = "rebase",
   Squash = "squash",
-  Merge = "merge"
+  Merge = "merge",
 }
 
 export interface FindPullRequestOptions {


### PR DESCRIPTION
- Modified mod.ts mergePullRequest method in order to pass as an option the merge method.
- Modified close command to pass the rebase merge method to mergePullRequest
- Added a missing await in case of an error for the openPullRequestMethod to better log the response